### PR TITLE
Upgrade pip from 9.x to currently latest one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ venv:
 
 .PHONY: reqs
 reqs: venv
-	$(VENV_DIR)/bin/pip install --upgrade "pip>=9.0,<9.1"
+	$(VENV_DIR)/bin/pip install --upgrade "pip>=19.0,<20.0"
 	$(VENV_DIR)/bin/pip install -r requirements.txt
 	$(VENV_DIR)/bin/pip install -r requirements-test.txt
 	$(VENV_DIR)/bin/python setup.py develop


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2/issues/4681 

With https://github.com/StackStorm/st2-packages/pull/614 and https://github.com/StackStorm/st2packaging-dockerfiles/pull/70 we can upgrade previously pinned pip 9 to currently latest one.

Related PR in st2: https://github.com/StackStorm/st2/pull/4712