### PR TITLE
FIX: Cryptic flake8 message.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flake8-copyright==0.2.2
+flake8-copyright==0.2.4
 flake8-polyfill==1.0.2


### PR DESCRIPTION
I was trying to run tox in another repository and discovered the following "issue" message:

    There was a critical error during execution of Flake8:
    plugin code for `flake8-copyright[flake8_copyright]` does not
    match ^[A-Z]{1,3}[0-9]{0,3}$

Therefore, I went searching and came accross this repository...

This patch fixes the issue by upgrading the flake8-copyright dependency from v0.2.2 to v0.2.4.

I don't expect any issue from any other downstreams st2 repos.