### PR TITLE
Maintenance: Switch from nose to pytest.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[coverage:run]
+omit =
+    */tests/*
+
+[coverage:report]
+fail_under = 70

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 flake8==3.7.7
-nose
-nosexcover
 pep8>=1.6.0,<1.7
 pylint>=1.4.3,<1.5
+pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ install_command = pip install -U --force-reinstall {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-test.txt
+    .
 commands =
-    nosetests -sv --with-xcoverage --cover-package=st2flake8 st2flake8.tests
+    pytest --cov=st2flake8 --cov-config={toxinidir}/.coveragerc st2flake8/tests
 
 [testenv:pep8]
 setenv = VIRTUALENV_DIR = {envdir}


### PR DESCRIPTION
This patch includes the following actions:

  - Remove node from dependency.
  - Add pytest and pytest-cov into dependency.
  - Add .coveragerc.