### PR TITLE
revert project name change from #10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_requirements():
 
 
 setup(
-    name="st2-flake8",
+    name="st2flake8",
     version=get_version_string(),
     author="StackStorm",
     author_email="info@stackstorm.com",


### PR DESCRIPTION
In #10, we changed the project name in setup.py from `st2flake8` to `st2-flake8`.

However, pypi gives me an error when I try to upload `st2-flake8` saying it is "too similar to an existing project name". pypi only supports renames that norrmalize to the same name (so changing case, or switching from `-` to `_`), but adding a `-` character changes the name in a way that cannot be handled by normalization rules. So, revert that to allow uploading v0.2.0.

Once this is merged, I'll try uploading v0.2.0 again.